### PR TITLE
Fixed unable to farm more then X drug & Fixed SQL File

### DIFF
--- a/esx_Illegal_drugs.sql
+++ b/esx_Illegal_drugs.sql
@@ -1,12 +1,12 @@
-USE `essentialmode`;
+USE `es_extended`;
 
-INSERT INTO `items` (name, label, `limit`) VALUES
-	('weed', 'Weed (1G)', 420),
-	('weed_pooch', 'Bag of weed (28G)', 15),
-	('coke', 'Coke (1G)', 420),
-	('coke_pooch', 'Bag of coke (28G)', 15),
-	('meth', 'Meth (1G)', 420),
-	('meth_pooch', 'Bag of meth (28G)', 15),
-	('opium', 'Opium (1G)', 420),
-	('opium_pooch', 'Bag of opium (28G)', 15)
+INSERT INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES
+	('weed', 'Weed (1G)', 1, 0, 1),
+	('weed_pooch', 'Weed Tasche (28G)', 28, 0, 1),
+	('coke', 'Cocain (1G)', 1, 0, 1),
+	('coke_pooch', 'Cocain Tasche (28G)', 28, 0, 1),
+	('meth', 'Meth (1G)', 1, 0, 1),
+	('meth_pooch', 'Meth Tasche (28G)', 28, 0, 1),
+	('opium', 'Opium (1G)', 1, 0, 1),
+	('opium_pooch', 'Opium Tasche (28G)', 28, 0, 1)
 ;

--- a/esx_Illegal_drugs.sql
+++ b/esx_Illegal_drugs.sql
@@ -2,11 +2,11 @@ USE `es_extended`;
 
 INSERT INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES
 	('weed', 'Weed (1G)', 1, 0, 1),
-	('weed_pooch', 'Weed Tasche (28G)', 28, 0, 1),
-	('coke', 'Cocain (1G)', 1, 0, 1),
-	('coke_pooch', 'Cocain Tasche (28G)', 28, 0, 1),
+	('weed_pooch', 'Bag of weed (28G)', 28, 0, 1),
+	('coke', 'Coke (1G)', 1, 0, 1),
+	('coke_pooch', 'Bag of coke (28G)', 28, 0, 1),
 	('meth', 'Meth (1G)', 1, 0, 1),
-	('meth_pooch', 'Meth Tasche (28G)', 28, 0, 1),
+	('meth_pooch', 'Bag of meth (28G)', 28, 0, 1),
 	('opium', 'Opium (1G)', 1, 0, 1),
-	('opium_pooch', 'Opium Tasche (28G)', 28, 0, 1)
+	('opium_pooch', 'Bag of opium (28G)', 28, 0, 1)
 ;

--- a/server/esx_illegal_drugs_sv.lua
+++ b/server/esx_illegal_drugs_sv.lua
@@ -642,16 +642,16 @@ local function SellMeth(source)
 					xPlayer.showNotification(_U('sold_one_meth'))
                 elseif CopsConnected >= 7 then
 					xPlayer.addAccountMoney('black_money', 4600)
-					xPlayer.showNotification(_U('sold_one_coke'))
+					xPlayer.showNotification(_U('sold_one_meth'))
                 elseif CopsConnected >= 8 then
 					xPlayer.addAccountMoney('black_money', 4700)
-					xPlayer.showNotification(_U('sold_one_coke'))
+					xPlayer.showNotification(_U('sold_one_meth'))
                 elseif CopsConnected >= 9 then
 					xPlayer.addAccountMoney('black_money', 4800)
-					xPlayer.showNotification(_U('sold_one_coke'))
+					xPlayer.showNotification(_U('sold_one_meth'))
                 elseif CopsConnected >= 10 then
 					xPlayer.addAccountMoney('black_money', 4900)
-					xPlayer.showNotification(_U('sold_one_coke'))	
+					xPlayer.showNotification(_U('sold_one_meth'))	
 				end
 				
 				SellMeth(source)

--- a/server/esx_illegal_drugs_sv.lua
+++ b/server/esx_illegal_drugs_sv.lua
@@ -39,7 +39,7 @@ local function HarvestWeed(source)
 		if PlayersHarvestingWeed[source] == true then
 			local weed = xPlayer.getInventoryItem('weed')
 
-			if not xPlayer.canCarryItem('weed', weed.count) then
+			if not xPlayer.canCarryItem('weed', weed.weight) then
 				xPlayer.showNotification(_U('inv_full_weed'))
 			else
 				xPlayer.addInventoryItem('weed', 1)
@@ -203,7 +203,7 @@ local function HarvestOpium(source)
 		if PlayersHarvestingOpium[source] == true then
 			local opium = xPlayer.getInventoryItem('opium')
 
-			if not xPlayer.canCarryItem('opium', opium.count) then
+			if not xPlayer.canCarryItem('opium', opium.weight) then
 				xPlayer.showNotification(_U('inv_full_opium'))
 			else
 				xPlayer.addInventoryItem('opium', 1)
@@ -366,7 +366,7 @@ local function HarvestCoke(source)
 		if PlayersHarvestingCoke[source] == true then
 			local coke = xPlayer.getInventoryItem('coke')
 
-			if not xPlayer.canCarryItem('coke', coke.count) then
+			if not xPlayer.canCarryItem('coke', coke.weight) then
 				xPlayer.showNotification(_U('inv_full_coke'))
 			else
 				xPlayer.addInventoryItem('coke', 1)
@@ -529,7 +529,7 @@ local function HarvestMeth(source)
 		if PlayersHarvestingMeth[source] == true then
 			local meth = xPlayer.getInventoryItem('meth')
 
-			if not xPlayer.canCarryItem('meth', meth.count) then
+			if not xPlayer.canCarryItem('meth', meth.weight) then
 				xPlayer.showNotification(_U('inv_full_meth'))
 			else
 				xPlayer.addInventoryItem('meth', 1)


### PR DESCRIPTION
DRUG.count is the wrong value for the calculation since it will compare the MaxWeight of the inventory and compare it against the count of the weed.

It should be compared if the player can carry the weight of the next drug badge not the count.

Example inventory space of 50.
I gather 26x weed.

```lua
xPlayer.canCarryItem('weed', weed.count) -- weed.count => 26
```
50-26 = 24
26 does not fit into 24
Return false

DRUG.weight will take the drug, lookup the weight in the DB and returns that.

edit:
Ops just updated the sql file for es_extended.
Should be right, not sure about if every setup has "rare" and "can_remove" tho.

edit:
Fixed wrong notification for sell meth